### PR TITLE
Refactoring MLP, MaskedMultiHeadAttention and TransformerDecoderBlock to their own modules

### DIFF
--- a/layers/__init__.py
+++ b/layers/__init__.py
@@ -1,2 +1,2 @@
 # Layers implemented for language modeling.
-from layers import bigram_lm, gpt, layer_utils
+from layers import bigram_lm, layer_utils, mlp, masked_multihead_attention, transformer_decoder_block, gpt

--- a/layers/gpt.py
+++ b/layers/gpt.py
@@ -1,100 +1,10 @@
 ''' Class implementing the GPT language model from scratch.
-
-    In the future. layers implemented in this file for multihead masked attention and
-    multilayer perceptrons can be moved to their own files for clarity.
 '''
 
 import torch, torch.nn as nn
 from typing import Optional
 
-class MLP(nn.Module):
-    '''
-        Multilayer perceptron consisting of a linear layer, a non linear activation (ReLU) and a second linear layer.
-    '''
-    def __init__(self, input_dimension: int, hidden_dimension: int, output_dimension: int):
-        '''
-            Args:
-                1. input_dimension - Dimension of the input to the layer.
-                2. hidden_dimension - Dimension of the output of the first linear layer.
-                3. output_dimension - Dimension of the output of the MLP module.
-        '''
-        super().__init__()
-        self.layer = nn.Sequential(
-            nn.Linear(input_dimension, hidden_dimension),
-            nn.ReLU(),
-            nn.Linear(hidden_dimension, output_dimension))
-
-    def forward(self, x):
-        return self.layer(x)
-
-class MultiHeadMaskedAttention(nn.Module):
-    '''
-        Multihead attention layer which can perform causal or non causal attention.
-    '''
-    def __init__(self, mask: bool, num_heads: int, head_dimension: int, input_dimension: int):
-        '''
-            Args:
-                1. mask - Whether to apply causal attention or not.
-                2. num_heads - Number of heads to use when computing multihead attention.
-                3. head_dimension - Dimension of the head embedding.
-                4. input_dimension - dimension of the input embedding.
-        '''
-        super().__init__()
-        self.mask: bool = mask
-        self.num_heads = num_heads
-        self.head_dimension = head_dimension
-        self.Wq = nn.Linear(input_dimension, num_heads * head_dimension) # (Re, nh * Rh)
-        self.Wk = nn.Linear(input_dimension, num_heads * head_dimension)
-        self.Wv = nn.Linear(input_dimension, num_heads * head_dimension)
-        self.head_merge_layer = nn.Linear(num_heads*head_dimension, input_dimension)
-
-    def forward(self, queries, keys, values):
-        # queries - (B, T, input_dimension)
-        (batch_size, block_size, _) = queries.shape
-        projected_queries = self.Wq(queries) # (B, T, nh*Rh)
-        reshaped_queries = projected_queries.view(-1, block_size, self.num_heads, self.head_dimension) # (B, T, nh, Rh)
-        transposed_queries = reshaped_queries.transpose(1, 2) # (B, nh, T, Rh)\
-
-        projected_keys = self.Wk(keys) # (B, T, nh*Rh)
-        reshaped_keys = projected_keys.view(-1, block_size, self.num_heads, self.head_dimension)
-        transposed_keys = reshaped_keys.transpose(1, 2) # (B, nh, T, Rh)
-
-        projected_values = self.Wv(values) # (B, T, nh*Rh)
-        reshaped_values = projected_values.view(-1, block_size, self.num_heads, self.head_dimension)
-        transposed_values = reshaped_values.transpose(1,2) # (B, nh, T, Rh)
-
-
-        attention = transposed_queries @ (transposed_keys.transpose(2, 3)) # (B, nh, T, T)
-        if self.mask:
-            tril_mat = torch.tril(torch.ones(block_size, block_size))
-            attention.masked_fill(tril_mat == 0, -torch.inf)
-        attention = nn.functional.softmax(attention, dim = 2) / self.head_dimension**(0.5) # (B, nh, T, T)
-        attention_output_multihead = attention @ transposed_values # (B, nh, T, Rh)
-
-        # Combining multiple heads.
-        transposed_attention_output_multihead = attention_output_multihead.transpose(1, 2) # (B, T, nh, Rh)
-        rehaped_attention_output_multihead = transposed_attention_output_multihead.contiguous().view(-1, block_size, self.num_heads * self.head_dimension)
-        attention_output = self.head_merge_layer(rehaped_attention_output_multihead)
-        return attention_output
-
-
-class TransformerDecoderBlock(nn.Module):
-    '''
-        Layer which applies a single Transformer Decoder block.
-    '''
-    def __init__(self, mask: bool, input_dimension: int, num_heads: int, head_dimension: int):
-        super().__init__()
-        self.attention_layer = MultiHeadMaskedAttention(mask, num_heads, head_dimension, input_dimension)
-        self.mlp_layer = MLP(input_dimension, 2 * input_dimension, input_dimension)
-        self.layer_norm = nn.LayerNorm(input_dimension)
-
-
-    def forward(self, x):
-        attention_output = self.attention_layer(x, x, x)
-        normalized_output = self.layer_norm(attention_output)
-        residual_output = x + normalized_output
-        mlp_output = self.mlp_layer(residual_output)
-        return mlp_output
+from layers.transformer_decoder_block import TransformerDecoderBlock
 
 
 class GPT(nn.Module):

--- a/layers/masked_multihead_attention.py
+++ b/layers/masked_multihead_attention.py
@@ -1,0 +1,55 @@
+'''
+    Class implementing masked multihead attention.
+'''
+
+import torch, torch.nn as nn
+
+class MaskedMultiHeadAttention(nn.Module):
+    '''
+        Multihead attention layer which can perform causal or non causal attention.
+    '''
+    def __init__(self, mask: bool, num_heads: int, head_dimension: int, input_dimension: int):
+        '''
+            Args:
+                1. mask - Whether to apply causal attention or not.
+                2. num_heads - Number of heads to use when computing multihead attention.
+                3. head_dimension - Dimension of the head embedding.
+                4. input_dimension - dimension of the input embedding.
+        '''
+        super().__init__()
+        self.mask: bool = mask
+        self.num_heads = num_heads
+        self.head_dimension = head_dimension
+        self.Wq = nn.Linear(input_dimension, num_heads * head_dimension) # (Re, nh * Rh)
+        self.Wk = nn.Linear(input_dimension, num_heads * head_dimension)
+        self.Wv = nn.Linear(input_dimension, num_heads * head_dimension)
+        self.head_merge_layer = nn.Linear(num_heads*head_dimension, input_dimension)
+
+    def forward(self, queries, keys, values):
+        # queries - (B, T, input_dimension)
+        (batch_size, block_size, _) = queries.shape
+        projected_queries = self.Wq(queries) # (B, T, nh*Rh)
+        reshaped_queries = projected_queries.view(-1, block_size, self.num_heads, self.head_dimension) # (B, T, nh, Rh)
+        transposed_queries = reshaped_queries.transpose(1, 2) # (B, nh, T, Rh)\
+
+        projected_keys = self.Wk(keys) # (B, T, nh*Rh)
+        reshaped_keys = projected_keys.view(-1, block_size, self.num_heads, self.head_dimension)
+        transposed_keys = reshaped_keys.transpose(1, 2) # (B, nh, T, Rh)
+
+        projected_values = self.Wv(values) # (B, T, nh*Rh)
+        reshaped_values = projected_values.view(-1, block_size, self.num_heads, self.head_dimension)
+        transposed_values = reshaped_values.transpose(1,2) # (B, nh, T, Rh)
+
+
+        attention = transposed_queries @ (transposed_keys.transpose(2, 3)) # (B, nh, T, T)
+        if self.mask:
+            tril_mat = torch.tril(torch.ones(block_size, block_size))
+            attention.masked_fill(tril_mat == 0, -torch.inf)
+        attention = nn.functional.softmax(attention, dim = 2) / self.head_dimension**(0.5) # (B, nh, T, T)
+        attention_output_multihead = attention @ transposed_values # (B, nh, T, Rh)
+
+        # Combining multiple heads.
+        transposed_attention_output_multihead = attention_output_multihead.transpose(1, 2) # (B, T, nh, Rh)
+        rehaped_attention_output_multihead = transposed_attention_output_multihead.contiguous().view(-1, block_size, self.num_heads * self.head_dimension)
+        attention_output = self.head_merge_layer(rehaped_attention_output_multihead)
+        return attention_output

--- a/layers/mlp.py
+++ b/layers/mlp.py
@@ -1,0 +1,24 @@
+''' Class implementing multilayer perceptron.
+'''
+
+from torch import nn
+
+class MLP(nn.Module):
+    '''
+        Multilayer perceptron consisting of a linear layer, a non linear activation (ReLU) and a second linear layer.
+    '''
+    def __init__(self, input_dimension: int, hidden_dimension: int, output_dimension: int):
+        '''
+            Args:
+                1. input_dimension - Dimension of the input to the layer.
+                2. hidden_dimension - Dimension of the output of the first linear layer.
+                3. output_dimension - Dimension of the output of the MLP module.
+        '''
+        super().__init__()
+        self.layer = nn.Sequential(
+            nn.Linear(input_dimension, hidden_dimension),
+            nn.ReLU(),
+            nn.Linear(hidden_dimension, output_dimension))
+
+    def forward(self, x):
+        return self.layer(x)

--- a/layers/transformer_decoder_block.py
+++ b/layers/transformer_decoder_block.py
@@ -1,0 +1,25 @@
+'''
+    Class implementing a transformer decoder block.
+'''
+
+from torch import nn
+from layers.mlp import MLP
+from layers.masked_multihead_attention import MaskedMultiHeadAttention
+
+class TransformerDecoderBlock(nn.Module):
+    '''
+        Layer which applies a single Transformer Decoder block.
+    '''
+    def __init__(self, mask: bool, input_dimension: int, num_heads: int, head_dimension: int):
+        super().__init__()
+        self.attention_layer = MaskedMultiHeadAttention(mask, num_heads, head_dimension, input_dimension)
+        self.mlp_layer = MLP(input_dimension, 2 * input_dimension, input_dimension)
+        self.layer_norm = nn.LayerNorm(input_dimension)
+
+
+    def forward(self, x):
+        attention_output = self.attention_layer(x, x, x)
+        normalized_output = self.layer_norm(attention_output)
+        residual_output = x + normalized_output
+        mlp_output = self.mlp_layer(residual_output)
+        return mlp_output


### PR DESCRIPTION
This allows better reuse of these classes, and also makes future features like adding LoRA finetuning easier.